### PR TITLE
tell ts to verify filename casing

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
 		"sourceMap": true,
 		"rootDir": "src",
 		"strict": true,
-		"noUnusedParameters": true
+		"noUnusedParameters": true,
+		"forceConsistentCasingInFileNames": true
 	},
 	"exclude": [
 		"node_modules",


### PR DESCRIPTION
While verifying https://github.com/microsoft/vscode/issues/94218 -- TS can actually protect you against this automatically, this change turns on that option 🙂 