### PR TITLE
feat: allow hiding issues from results

### DIFF
--- a/src/renderer/renderer.css
+++ b/src/renderer/renderer.css
@@ -1,10 +1,13 @@
 .item-row {
-	display: flex;
-	padding: 0.5em 0;
+	padding: 0.3em;
 	color: var(--vscode-foreground);
 }
 .item-row:hover {
 	background-color: var(--vscode-list-hoverBackground);
+}
+.item-main {
+	display: flex;
+	align-items: center;
 }
 .title {
 	color: var(--vscode-foreground) !important;
@@ -27,9 +30,11 @@
 	padding: 2px;
 }
 .status {
+	display: flex;
+	align-items: center;
 	font-size: 0.8em;
 	opacity: 60%;
-	padding-top: 0.5em;
+	padding: 0.1em 0 0.1em 0.3em;
 }
 .assignee {
 	flex: shrink;
@@ -38,15 +43,15 @@
 	display: flex;
 }
 .user img {
-	padding: 0.1em;
+	padding: 0 0.1em;
 }
 .item-state {
-	flex: shrink;
-	padding: 0 0.3em;
+	padding-right: 0.3em;
 	opacity: 60%;
 }
 .item-state .octicon {
 	fill: var(--vscode-icon-foreground);
+	display: block;
 }
 .item-state .octicon.open {
 	fill: var(--vscode-editorWarning-foreground);
@@ -85,4 +90,22 @@
 }
 .item-row:hover .start-working {
 	display: inline;
+}
+.item-row .actions {
+	display: none;
+	margin: 0;
+	padding: 0;
+}
+.item-row:hover .actions,
+.item-row:focus-within .actions {
+	display: flex;
+}
+.item-row .actions li {
+	list-style-type: none;
+	padding: 0;
+	cursor: pointer;
+}
+
+.item-row .actions li a {
+	color: inherit;
 }


### PR DESCRIPTION
When working on one area I often do several issues and push them up in bulk so that I can rebase/combine/revert local changes. In these cases I 'complete' issues but don't close them. So I added some functionality to the issues notebook that lets users hide issues from their results.

![](https://memes.peet.io/img/21-03-daf0c5f9-5f00-4345-84c5-d3b081bcaa4a.png)

I also changed the layout slightly to make sure this fits and can be shown consistently.