### PR TITLE
Add "small batch opening", copy to clipboard functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,18 @@
 	"main": "./dist/extension-node.js",
 	"browser": "./dist/extension-web.js",
 	"contributes": {
+		"configuration": {
+			"type": "object",
+			"title": "Github Issues",
+			"properties": {
+				"github-issues.maxToOpenInOneTab": {
+					"type": "number",
+					"default": 50,
+					"description": "Maximum batch size of results to open in a single browser tab",
+					"scope": "resource"
+				}
+			}
+		},
 		"languages": [
 			{
 				"id": "github-issues",

--- a/src/extension/commands.ts
+++ b/src/extension/commands.ts
@@ -94,6 +94,9 @@ export function registerCommands(projectContainer: ProjectContainer, octokit: Oc
 			return;
 		}
 
+		let config = vscode.workspace.getConfiguration();
+		let max_results: number = (config.get('github-issues.maxToOpenInOneTab') ?? 50);
+
 		// Get the unique set of repos from the list.
 		let repos = [...new Set(Array.from(items, x => x.html_url.replace(/(\/[\d]+$)/g, '')))];
 
@@ -103,11 +106,11 @@ export function registerCommands(projectContainer: ProjectContainer, octokit: Oc
 
 			// There is some hard limit to the number of results that can be opened by number. 
 			// Seems like it always accepts at least 50, so limiting it to that.
-			if (results.length > 50) {
+			if (results.length > max_results) {
 				await vscode.window.showInformationMessage(
-					`Truncated results to 50 from ${r}.`,
+					`Truncated results to ${max_results} from ${r}.`,
 				);
-				results = results.slice(0, 50);
+				results = results.slice(0, max_results);
 			}
 
 			if (results.length > 0) {

--- a/src/extension/notebookProvider.ts
+++ b/src/extension/notebookProvider.ts
@@ -27,6 +27,7 @@ export class IssuesNotebookKernel {
 
 	private readonly _controller: vscode.NotebookController;
 	private _executionOrder = 0;
+	private _config = vscode.workspace.getConfiguration('vscode-github-issue-notebooks');
 
 	constructor(
 		readonly container: ProjectContainer,
@@ -220,9 +221,9 @@ export class IssuesStatusBarProvider implements vscode.NotebookCellStatusBarItem
 		openByQuery.command = 'github-issues.openQuery';
 		openByQuery.tooltip = `Open ${count} results in browser as a query, which may not accurately reflect these results`;
 
-		let openByNumber = new vscode.NotebookCellStatusBarItem(`$(inbox) Open only these`, vscode.NotebookCellStatusBarAlignment.Right);
+		let openByNumber = new vscode.NotebookCellStatusBarItem(`$(inbox) Open batch`, vscode.NotebookCellStatusBarAlignment.Right);
 		openByNumber.command = 'github-issues.openResultsByNumbers';
-		openByNumber.tooltip = `Open up to 50 of these specific results in single browser tab`;
+		openByNumber.tooltip = `Open these specific results in single browser tab via their id numbers. Max can be adjust via the github-issues.maxToOpenInOneTab setting`;
 
 
 


### PR DESCRIPTION
Added some widgets to make it easier to use github-issues notebook easier to use for issue management. Added:
- Ability to open issues in the browser by small batches
- Ability to copy the expanded query to clipboard

![image](https://user-images.githubusercontent.com/11685408/136874636-f539935b-2498-4066-a41c-37b509e61cc0.png)

Open as query was added to the cell status bar because I don't normally have the cell toolbar on with hover. Putting it on the cell status bar made it more convenient to get to since you'd most likely use it after running the cell anyway (even if it's not necessary). 

