### PR TITLE
Add notebook group to newFile contribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
 			],
 			"file/newFile": [
 				{
-					"command": "github-issues.new"
+					"command": "github-issues.new",
+					"group": "notebook"
 				}
 			]
 		}


### PR DESCRIPTION
Based on https://github.com/microsoft/vscode/issues/146022.

This PR adds a group key to the newFile contribution so that the notebook can show up in the same category as other notebook extensions.